### PR TITLE
[x86] Remove heap section from linker.

### DIFF
--- a/arch/x86/cpu/x86_64/linker.ld
+++ b/arch/x86/cpu/x86_64/linker.ld
@@ -69,14 +69,6 @@ SECTIONS
 		PROVIDE(_percpu_end = .);
 	}
 
-	.heap :
-	{
-		. = ALIGN(4096);
-		PROVIDE(_heap_start = .);
-		. = . + (CONFIG_HEAP_SIZE_MB * 1024 * 1024);
-		PROVIDE(_eheap = .);
-	}
-
         .stack :
         {
                 . = ALIGN(4096);


### PR DESCRIPTION
Heap section in linker was bloating the binary.
Now Xvisor allocats heap memory on the fly so its
not needed.

Signed-off-by: Himanshu Chauhan hschauhan@nulltrace.org
