### PR TITLE
[x86] Make the package installation automated

### DIFF
--- a/tests/x86/make_x86_setup
+++ b/tests/x86/make_x86_setup
@@ -44,7 +44,7 @@ function run_or_die() {
 }
 
 function prepare_environment() {
-    run_or_die "sudo apt-get install ${PACKAGES}" "Building conducive environtment..."
+    run_or_die "sudo apt-get -y install ${PACKAGES}" "Building conducive environtment..."
 }
 
 function checkout_coreboot() {


### PR DESCRIPTION
Currently, while installing the required packages,
the script asks for the password. Make it automated.

Signed-off-by: Himanshu Chauhan hschauhan@nulltrace.org
