### PR TITLE
fixed incorrect use of mcpu

### DIFF
--- a/arch/arm/cpu/arm32ve/objects.mk
+++ b/arch/arm/cpu/arm32ve/objects.mk
@@ -29,9 +29,9 @@
 arch-$(CONFIG_ARMV7A_VE) += -march=armv7ve -mno-thumb-interwork
 
 # This selects how we optimise for the processor.
-tune-$(CONFIG_CPU_CORTEX_A15) += -mcpu=cortex-a15
-tune-$(CONFIG_CPU_CORTEX_A7) += -mcpu=cortex-a7
-tune-$(CONFIG_CPU_GENERIC_V7_VE) += -mcpu=cortex-a15
+tune-$(CONFIG_CPU_CORTEX_A15) += -mtune=cortex-a15
+tune-$(CONFIG_CPU_CORTEX_A7) += -mtune=cortex-a7
+tune-$(CONFIG_CPU_GENERIC_V7_VE) += -mtune=cortex-a15
 
 # Need -Uarm for gcc < 3.x
 cpu-cppflags+=-DTEXT_START=0x10000000

--- a/tests/arm32/realview-pb-a8/basic/Makefile
+++ b/tests/arm32/realview-pb-a8/basic/Makefile
@@ -42,8 +42,8 @@ board_objs       = $(obj_dir)/arm_board.o \
 board_fdt_support = y
 
 board_cppflags   =
-board_cflags     = -mcpu=cortex-a8
-board_asflags    = -mcpu=cortex-a8
+board_cflags     = -mtune=cortex-a8
+board_asflags    = -mtune=cortex-a8
 board_ldflags    =
 
 # Include common makefile for basic firmware

--- a/tests/arm32/sabrelite/basic/Makefile
+++ b/tests/arm32/sabrelite/basic/Makefile
@@ -43,8 +43,8 @@ board_fdt_support = y
 board_smp	 = y
 
 board_cppflags   =
-board_cflags     = -mcpu=cortex-a9
-board_asflags    = -mcpu=cortex-a9
+board_cflags     = -mtune=cortex-a9
+board_asflags    = -mtune=cortex-a9
 board_ldflags    =
 
 # Include common makefile for basic firmware

--- a/tests/arm32/vexpress-a15/basic/Makefile
+++ b/tests/arm32/vexpress-a15/basic/Makefile
@@ -44,8 +44,8 @@ board_secure_extn = y
 board_smp	  = y
 
 board_cppflags   =
-board_cflags     = -mcpu=cortex-a15
-board_asflags    = -mcpu=cortex-a15
+board_cflags     = -mtune=cortex-a15
+board_asflags    = -mtune=cortex-a15
 board_ldflags    =
 
 # Include common makefile for basic firmware

--- a/tests/arm32/vexpress-a15/basic/README
+++ b/tests/arm32/vexpress-a15/basic/README
@@ -46,7 +46,7 @@ Guest with Xvisor running on ARM Fast Model VExpress-A15 Host:
   # genext2fs -B 1024 -b 16384 -d ./build/disk ./build/disk.img
 
   [8. Create fast_model_boot.axf for running it on ARM Fast Models]
-  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mcpu=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_vexpress-a15.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
+  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mtune=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_vexpress-a15.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
 
   [9. Launch ARM fast models 8.0 or higher]
   # model_shell <your_fastmodel_dir>/FastModelsPortfolio_<xxxx>/examples/FVP_VE/Build_Cortex-A15x1/Linux-Debug-GCC-<yyyy>/cadi_system_Linux-Debug-GCC-<yyyy>.so build/fast_model_boot.axf

--- a/tests/arm32/vexpress-a15/linux/README
+++ b/tests/arm32/vexpress-a15/linux/README
@@ -70,7 +70,7 @@ RootFS on VExpress-A15 Guest with Xvisor running on ARM Fast Models Host:
   # genext2fs -B 1024 -b 16384 -d ./build/disk ./build/disk.img
 
   [14. Create fast_model_boot.axf for running it on ARM Fast Models]
-  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mcpu=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_vexpress-a15.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
+  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mtune=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_vexpress-a15.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
 
   [15. Launch ARM fast models 8.0 or higher]
   # model_shell <your_fastmodel_dir>/FastModelsPortfolio_<xxxx>/examples/FVP_VE/Build_Cortex-A15x1/Linux-Debug-GCC-<yyyy>/cadi_system_Linux-Debug-GCC-<yyyy>.so build/fast_model_boot.axf

--- a/tests/arm32/vexpress-a9/basic/Makefile
+++ b/tests/arm32/vexpress-a9/basic/Makefile
@@ -43,8 +43,8 @@ board_fdt_support = y
 board_smp	 = y
 
 board_cppflags   =
-board_cflags     = -mcpu=cortex-a9
-board_asflags    = -mcpu=cortex-a9
+board_cflags     = -mtune=cortex-a9
+board_asflags    = -mtune=cortex-a9
 board_ldflags    =
 
 # Include common makefile for basic firmware

--- a/tests/arm32/vexpress-a9/freertos/Makefile
+++ b/tests/arm32/vexpress-a9/freertos/Makefile
@@ -92,7 +92,7 @@ ifeq ($(BOARD_FDT_SUPPORT),y)
 CPPFLAGS += -DBOARD_FDT_SUPPORT
 endif
 
-CFLAGS  = -mcpu=cortex-a9 -march=armv7-a -Wall -Werror  \
+CFLAGS  = -mtune=cortex-a9 -march=armv7-a -Wall -Werror  \
           -nostdlib -msoft-float -marm
 ASFLAGS = -D__ASSEMBLY__ $(CFLAGS)
 LDFLAGS = -Wl,-T$(LINK_SCRIPT_GEN) -nostdlib -Wl,--build-id=none

--- a/tests/arm32/virt-v7/basic/Makefile
+++ b/tests/arm32/virt-v7/basic/Makefile
@@ -45,8 +45,8 @@ board_secure_extn = y
 board_smp	  = y
 
 board_cppflags   =
-board_cflags     = -mcpu=cortex-a15
-board_asflags    = -mcpu=cortex-a15
+board_cflags     = -mtune=cortex-a15
+board_asflags    = -mtune=cortex-a15
 board_ldflags    =
 
 # Include common makefile for basic test

--- a/tests/arm32/virt-v7/basic/README
+++ b/tests/arm32/virt-v7/basic/README
@@ -45,7 +45,7 @@ Guest with Xvisor running on ARM Fast Model VExpress-A15 Host:
   # genext2fs -B 1024 -b 16384 -d ./build/disk ./build/disk.img
 
   [8. Create fast_model_boot.axf for running it on ARM Fast Models]
-  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mcpu=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_virt-v7.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
+  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mtune=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_virt-v7.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
 
   [9. Launch ARM fast models 8.0 or higher]
   # model_shell <your_fastmodel_dir>/FastModelsPortfolio_<xxxx>/examples/FVP_VE/Build_Cortex-A15x1/Linux-Debug-GCC-<yyyy>/cadi_system_Linux-Debug-GCC-<yyyy>.so build/fast_model_boot.axf

--- a/tests/arm32/virt-v7/linux/README
+++ b/tests/arm32/virt-v7/linux/README
@@ -70,7 +70,7 @@ ARM Fast Models Host:
   # genext2fs -B 1024 -b 16384 -d ./build/disk ./build/disk.img
 
   [14. Create fast_model_boot.axf for running it on ARM Fast Models]
-  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mcpu=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_virt-v7.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
+  # ${CROSS_COMPILE}gcc -nostdlib -march=armv7ve -mtune=cortex-a15 -e start_boot -Wl,--build-id=none -Wl,-Ttext=0x80000000 -DSPIN_LOCATION=0x1c010030 -DSPIN_LOOP_ADDR=0x14000000 -DUART_PL011 -DUART_PL011_BASE=0x1c090000 -DGENTIMER_FREQ=100000000 -DGICv2 -DGIC_DIST_BASE=0x2c001000 -DGIC_CPU_BASE=0x2c002000 -DIMAGE=build/vmm.bin -DDTB=build/arch/arm/board/generic/dts/vexpress/a15/one_guest_virt-v7.dtb -DINITRD=build/disk.img ./docs/arm/fast_model_boot.S -o build/fast_model_boot.axf
 
   [15. Launch ARM fast models 8.0 or higher]
   # model_shell <your_fastmodel_dir>/FastModelsPortfolio_<xxxx>/examples/FVP_VE/Build_Cortex-A15x1/Linux-Debug-GCC-<yyyy>/cadi_system_Linux-Debug-GCC-<yyyy>.so build/fast_model_boot.axf


### PR DESCRIPTION
Recent versions of gcc consider it an error rather than a warning, and refuse to compile. Instead of mcpu, it should be mtune