### PR TITLE
tools/openconf: fix check-lxdialog.sh for binutils 2.29.1-1

### DIFF
--- a/tools/openconf/lxdialog/check-lxdialog.sh
+++ b/tools/openconf/lxdialog/check-lxdialog.sh
@@ -4,16 +4,17 @@
 # What library to link
 ldflags()
 {
+	LIBS=""
 	for ext in so a dylib ; do
-		for lib in ncursesw ncurses curses ; do
+		for lib in ncursesw ncurses curses tinfo; do
 			$cc -print-file-name=lib${lib}.${ext} | grep -q /
 			if [ $? -eq 0 ]; then
-				echo "-l${lib}"
-				exit
+				LIBS="${LIBS} -l${lib}"
 			fi
 		done
 	done
-	exit 1
+	[ -z "${LIBS}" ] && exit 1
+	echo "${LIBS}"
 }
 
 # Where is ncurses.h?


### PR DESCRIPTION
When using binutils 2.29.1-1 (on ArchLinux), calling the Xvisor
menuconfig, the following error appears:
/usr/bin/ld: lxdialog/checklist.o: undefined reference to symbol 'acs_map'
/usr/lib/libtinfo.so.6: error adding symbols: DSO missing from command
  line

This error comes from a change in binutils regarding the DSO linking, so
"ld will no longer skip linking needed libraries by default" (source:
http://fedoraproject.org/wiki/UnderstandingDSOLinkChange)

To correct the issue, tinfo should explicitely be added in the library
list. For this to be possible and properly integrated, the "ldflags"
function from lxdialog/check-lxdialog.sh returns all the libraries found
instead of the first one.

This was reported by Paul Nicolas <paul.nicolas at epita.fr>.

Signed-off-by: Paul Nicolas <paul.nicolas@epita.fr>
Signed-off-by: Jimmy Durand Wesolowski <jimmy.durand.wesolowski@gmail.com>