### PR TITLE
Travis Autobuild for x86

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+before_install:
+    - sudo apt-get -y install dtc
+
+dist: bionic
+branches:
+    only:
+        - x86-next
+script:
+    - make ARCH=x86 x86_64_generic-defconfig
+    - make
+os:
+    - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 before_install:
-    - sudo apt-get -y install dtc
+    - sudo apt-get -y install device-tree-compiler
 
 dist: bionic
 branches:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![x86 Build Status](https://travis-ci.com/hschauhan/xvisor-x86_64.svg?branch=x86-next)](https://travis-ci.com/hschauhan/xvisor-x86_64)
+[![x86 Build Status](https://travis-ci.com/hschauhan/xvisor-x86_64.svg?branch=x86-next)](https://travis-ci.com/hschauhan/xvisor-x86)
 
 # Xvisor
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![x86 Build Status](https://travis-ci.com/hschauhan/xvisor-x86_64.svg?branch=x86-next)](https://travis-ci.com/hschauhan/xvisor-x86)
+[![Build Status](https://travis-ci.com/hschauhan/xvisor-x86.svg?branch=x86-next)](https://travis-ci.com/hschauhan/xvisor-x86)
 
 # Xvisor
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![x86 Build Status](https://travis-ci.com/hschauhan/xvisor-x86_64.svg?branch=x86-next)](https://travis-ci.com/hschauhan/xvisor-x86_64)
+
 # Xvisor
 
 http://xvisor.org


### PR DESCRIPTION
Enable Travis autobuild for x86 for continuous integration. We can add ARM and RISCV also to it.